### PR TITLE
Update apache-spark-python-package-installation.md

### DIFF
--- a/articles/hdinsight/spark/apache-spark-python-package-installation.md
+++ b/articles/hdinsight/spark/apache-spark-python-package-installation.md
@@ -127,16 +127,16 @@ HDInsight cluster depends on the built-in Python environment, both Python 2.7 an
         Using the terminal or a notebook, use the `spark.conf.set` function.
 
         ```spark
-        spark.conf.set("spark.yarn.appMasterEnv.PYSPARK_PYTHON", "/usr/bin/anaconda/envs/py35/bin/python")
-        spark.conf.set("spark.yarn.appMasterEnv.PYSPARK_DRIVER_PYTHON", "/usr/bin/anaconda/envs/py35/bin/python")
+        spark.conf.set("spark.yarn.appMasterEnv.PYSPARK_PYTHON", "/usr/bin/anaconda/envs/py35new/bin/python")
+        spark.conf.set("spark.yarn.appMasterEnv.PYSPARK_DRIVER_PYTHON", "/usr/bin/anaconda/envs/py35new/bin/python")
         ```
 
         If you are using livy, add the following properties to the request body:
 
         ```
         “conf” : {
-        “spark.yarn.appMasterEnv.PYSPARK_PYTHON”:”/usr/bin/anaconda/envs/py35/bin/python”,
-        “spark.yarn.appMasterEnv.PYSPARK_DRIVER_PYTHON”:”/usr/bin/anaconda/envs/py35/bin/python”
+        “spark.yarn.appMasterEnv.PYSPARK_PYTHON”:”/usr/bin/anaconda/envs/py35new/bin/python”,
+        “spark.yarn.appMasterEnv.PYSPARK_DRIVER_PYTHON”:”/usr/bin/anaconda/envs/py35new/bin/python”
         }
         ```
 


### PR DESCRIPTION
Wrong file location specified in step number 5, wrong folder name from py35 to py35new in four locations